### PR TITLE
Fix random selection off-by-one

### DIFF
--- a/play-random-sample.sh
+++ b/play-random-sample.sh
@@ -41,9 +41,12 @@ else
 fi
 echo
 echo -e "\U1F477Generating random choice from scanned audio and video files..."
-num_files=${#files[*]} # Count how many elements.
-num_files=`expr $num_files - 1`;
-choice="${files[$((RANDOM%num_files))]}"
+num_files=${#files[@]} # Count how many elements.
+if [ "$num_files" -eq 0 ]; then
+    echo "No audio or video files found."
+    exit 1
+fi
+choice="${files[RANDOM % num_files]}"
 # Show controls for Alsaplayer
 #echo
 #echo -e "${CLI}Controls${NC} (case sensitive !)


### PR DESCRIPTION
## Summary
- correct random index calculation to include all files
- add guard when no audio or video files are found

## Testing
- `bash -n play-random-sample.sh`
- `bash play-random-sample.sh` *(fails: tree: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5abe20cf083318ed2c88bf30e8041