### PR TITLE
docs: fix typo in screenshot alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Integrated CLI DJ'ing Environment
 
-![play-radnom-sample screen shot](https://github.com/Michael-Z-Freeman/play-random-sample/raw/main/play_random_sample_screenshot.png "screen shot") 
+![play-random-sample screen shot](https://github.com/Michael-Z-Freeman/play-random-sample/raw/main/play_random_sample_screenshot.png "screen shot")
 
 Scan folder and sub-folders for all audio &amp; video, cache results, then play random selection.
 


### PR DESCRIPTION
## Summary
- fix typo in README screenshot alt text

## Testing
- `bash -n play-random-sample.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a5acc187f08331ab81afcb3b2dc412