### PR TITLE
chore: clean up unused color comment

### DIFF
--- a/play-random-sample.sh
+++ b/play-random-sample.sh
@@ -3,10 +3,10 @@ IFS=$'\n'
 count=0
 dir=$(pwd)
 cache=.play-random-cache-$(echo "$dir" | tr / -)
-# https://gist.github.com/vratiu/9780109 (Colour table)
-TITLE='\033[1;33m' # BLUE='\033[0;34m'
-CLI='\033[4;37m'
-NC='\033[0m'
+# Colour constants from https://gist.github.com/vratiu/9780109
+TITLE='\033[1;33m'  # Bold yellow
+CLI='\033[4;37m'    # Underlined white
+NC='\033[0m'        # Reset/No colour
 DIR=''
 FILE=''
 echo


### PR DESCRIPTION
## Summary
- Remove unused BLUE color comment and clarify color constant descriptions

## Testing
- `bash -n play-random-sample.sh`
- `shellcheck play-random-sample.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5accfd99483318536212b1d10f4de